### PR TITLE
merge extra dockerfile instructions

### DIFF
--- a/1.0/x86_64/Dockerfile
+++ b/1.0/x86_64/Dockerfile
@@ -2,28 +2,18 @@ FROM node:6.11.1-alpine
 
 ENV NPM_CONFIG_LOGLEVEL warn
 
-
-USER root
-WORKDIR /root/
-
-WORKDIR /var/www/
-RUN npm install -g ghost-cli
-
-RUN addgroup www-data
-RUN adduser ghost -G www-data -S /bin/bash
-RUN chown ghost:www-data .
+WORKDIR /var/www/ghost
+RUN npm install -g ghost-cli && \
+    addgroup www-data && \
+    adduser ghost -G www-data -S /bin/bash && \
+    chown ghost:www-data -R /var/www/ghost
 
 USER ghost
-WORKDIR /var/www/
-RUN mkdir -p ghost
-WORKDIR /var/www/ghost
-
-RUN ghost install local --no-start
+RUN ghost install local --no-start && \
+    sed -ie s/127.0.0.1/0.0.0.0/g config.development.json
 
 EXPOSE 2368
 EXPOSE 2369
 
 ENV NODE_ENV production
-RUN sed -ie s/127.0.0.1/0.0.0.0/g config.development.json
-
 CMD ["ghost", "run", "--development", "--ip", "0.0.0.0"]


### PR DESCRIPTION
Hi, @alexellis Thanks for your ghost 1.0.0 Dockerfile, the image works well.
But I notice your `1.0/x86_64/Dockerfile` has too many instructions which leads to built image having too many layers. So I simpily the dockerfile,merge some instructions to one instruction.

I have built and test the new dockerfile.